### PR TITLE
Fix: Preserve nested event fields in request body by using deep merge

### DIFF
--- a/template.js
+++ b/template.js
@@ -12,7 +12,7 @@ const isDebug = containerVersion.debugMode;
 const isLoggingEnabled = determinateIsLoggingEnabled();
 const traceId = getRequestHeader('trace-id');
 
-const postHeaders = {'Content-Type': 'application/json'};
+const postHeaders = { 'Content-Type': 'application/json' };
 let postBodyData = {};
 
 if (data.includeEventData) {
@@ -42,7 +42,7 @@ if (data.inside_array) {
 }
 
 const postBody = JSON.stringify(postBodyData);
-let requestOptions = {headers: postHeaders, method: data.requestMethod};
+let requestOptions = { headers: postHeaders, method: data.requestMethod };
 
 if (data.requestTimeout) {
     requestOptions.timeout = makeInteger(data.requestTimeout);
@@ -119,20 +119,27 @@ function createSimpleObject() {
     return makeTableMap(data.data, 'key', 'value');
 }
 
+function deepMerge(target, source) {
+    if (!target || typeof target !== 'object') {
+        target = {};
+    }
+    for (var key in source) {
+        if (!source.hasOwnProperty(key)) continue;
 
-function mergeObjects() {
-    let obj = {},
-        i = 0,
-        il = arguments.length,
-        key;
-    for (; i < il; i++) {
-        for (key in arguments[i]) {
-            if (arguments[i][key]) {
-                obj[key] = arguments[i][key];
-            }
+        var sv = source[key];
+        var tv = target[key];
+
+        if (sv && typeof sv === 'object') {
+            // no Array check, assume it's always an object-like
+            target[key] = deepMerge(
+                (tv && typeof tv === 'object') ? tv : {},
+                sv
+            );
+        } else {
+            target[key] = sv;
         }
     }
-    return obj;
+    return target;
 }
 
 function createNestedObject() {
@@ -144,7 +151,7 @@ function createNestedObject() {
         let strObj = strToObj(dotPath, data.data[key].value)[rootProperty];
 
         if (object[rootProperty]) {
-            object[rootProperty] = mergeObjects(object[rootProperty], strObj);
+            object[rootProperty] = deepMerge(object[rootProperty], strObj);
         } else {
             object[rootProperty] = strObj;
         }


### PR DESCRIPTION
## Title
Fix: Preserve nested event fields in request body by using deep merge

## Summary
This PR fixes an issue where nested keys under the same root (e.g. `d.event.*`) were being **overwritten** instead of merged, resulting in incomplete request bodies being sent.

## Problem
- The current implementation uses a **shallow merge** (`mergeObjects`) inside `createNestedObject()`.
- When multiple keys share the same top-level property (e.g. `d.event.props.page.title`, `d.event.name`, `d.event.time`), each subsequent merge overwrites the entire `event` object.
- This caused the request body to lose most of its nested structure, keeping only the last field encountered.

### Example input config
```json
[
  {"key": "d.msgId", "value": "..."},
  {"key": "d.visId", "value": "..."},
  {"key": "d.event.props.page.title", "value": "Example Title"},
  {"key": "d.event.props.page.url", "value": "https://example.com/page"},
  {"key": "d.event.props.page.referredUrl", "value": "example.com"},
  {"key": "d.event.props.isCustomEvent", "value": "true"},
  {"key": "d.event.props.vwoMeta.source", "value": "client"},
  {"key": "d.event.name", "value": "customEventName"},
  {"key": "d.event.time", "value": 1234567890},
  {"key": "d.sessionId", "value": 987654321}
]
```

### Old output
```json
{
  "d": {
    "msgId": "...",
    "visId": "...",
    "event": { "time": 1234567890 },
    "sessionId": 987654321
  }
}
```

Most of the `d.event.*` structure is missing.

## Fix
- Replaced the shallow `mergeObjects()` with a new `deepMerge()` function.
- `deepMerge()` recursively merges objects so that nested properties are combined instead of replaced.
- Adjusted `createNestedObject()` to use `deepMerge()` for combining sub-objects.

### New output
```json
{
  "d": {
    "msgId": "...",
    "visId": "...",
    "event": {
      "props": {
        "page": {
          "title": "Example Title",
          "url": "https://example.com/page",
          "referredUrl": "example.com"
        },
        "isCustomEvent": "true",
        "vwoMeta": { "source": "client" }
      },
      "name": "customEventName",
      "time": 1234567890
    },
    "sessionId": 987654321
  }
}
```

## Impact
- Ensures all nested `d.event.*` fields are preserved in the request payload.
- Backward-compatible for cases without nested keys.
- Logging and request sending behavior remain unchanged.

## Next Steps
- Consider also applying deep merge at the **top-level merge** (`postBodyCustomData` into `postBodyData`) to avoid overwriting when both `includeEventData` and custom data define the same root object (e.g. `d`).
